### PR TITLE
Check ADB authorization and load MDM apps from directories

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -286,6 +286,13 @@ body {
     position: relative;
 }
 
+.app-icon img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    border-radius: 0.5rem;
+}
+
 .command-indicator {
     position: absolute;
     top: -4px;


### PR DESCRIPTION
## Summary
- wait for Android device authorization before finishing ADB connection
- serve app metadata from `/apk` directories with images and Cloudflare APK URLs
- render app cards with directory images and download/execute post-install commands

## Testing
- `npm test` *(fails: Missing script)*
- `node server.js & curl http://localhost:8000/api/apks | head -c 200`


------
https://chatgpt.com/codex/tasks/task_e_68b5be5f2b688325a5eb95a9546a0094