### PR TITLE
Add dynamic MDM kit installer

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -255,7 +255,7 @@ body {
     background: linear-gradient(135deg, var(--card-gradient-start), var(--card-gradient-end));
     border: 2px solid var(--border-color);
     border-radius: 0.5rem;
-    cursor: pointer;
+    cursor: default;
     transition: all 0.2s;
 }
 
@@ -270,6 +270,11 @@ body {
     background: linear-gradient(135deg, var(--success-gradient-start), var(--success-gradient-end));
     color: white;
     border-color: var(--success-color);
+}
+
+.app-item .install-btn {
+    margin-top: 0.5rem;
+    width: 100%;
 }
 
 .app-icon {

--- a/index.html
+++ b/index.html
@@ -56,57 +56,7 @@
             <!-- APK Installation Card -->
             <div class="card install-card" id="installCard">
                 <h2>Install MDM Applications</h2>
-                
-                <!-- Pre-configured MDM APKs -->
-                <div class="mdm-apps">
-                    <h3>Quick Install</h3>
-                    <div class="app-grid" id="presetApps">
-                        <button class="app-item" data-apk="workspace-one">
-                            <div class="app-icon">WS1</div>
-                            <span>Workspace ONE</span>
-                        </button>
-                        <button class="app-item" data-apk="intune">
-                            <div class="app-icon">MS</div>
-                            <span>Microsoft Intune</span>
-                        </button>
-                        <button class="app-item" data-apk="meraki">
-                            <div class="app-icon">SM</div>
-                            <span>Meraki SM</span>
-                        </button>
-                        <button class="app-item" data-apk="custom">
-                            <div class="app-icon">+</div>
-                            <span>Custom APK</span>
-                        </button>
-                    </div>
-                </div>
-
-                <!-- Custom APK Upload -->
-                <div class="upload-section hidden" id="uploadSection">
-                    <div class="upload-area" id="uploadArea">
-                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                            <polyline points="17 8 12 3 7 8"></polyline>
-                            <line x1="12" y1="3" x2="12" y2="15"></line>
-                        </svg>
-                        <p>Drop APK files here or click to browse</p>
-                        <input type="file" id="apkInput" accept=".apk" multiple hidden>
-                    </div>
-                </div>
-
-                <!-- APK Queue -->
-                <div class="apk-queue hidden" id="apkQueue">
-                    <h3>Installation Queue</h3>
-                    <div class="queue-list" id="queueList"></div>
-                    <div class="queue-actions">
-                        <button class="btn btn-secondary" id="clearQueueBtn">Clear All</button>
-                        <button class="btn btn-primary" id="installBtn">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M19 11H5m14 0l-7 7m7-7l-7-7"></path>
-                            </svg>
-                            Install All
-                        </button>
-                    </div>
-                </div>
+                <div class="app-grid" id="kitsGrid"></div>
             </div>
 
             <!-- Progress Card -->

--- a/server.js
+++ b/server.js
@@ -30,7 +30,7 @@ const server = http.createServer((req, res) => {
       }
 
       const apps = entries
-        .filter(entry => entry.isDirectory())
+        .filter(entry => entry.isDirectory() && entry.name !== 'blog')
         .map(dir => {
           const dirPath = path.join('./apk', dir.name);
 


### PR DESCRIPTION
## Summary
- Replace static MDM install section with dynamic kit grid sourced from `/api/apks`.
- Style kit cards and install buttons for clearer interaction.
- Exclude non-app directories from APK listing API.
- Implement single-kit installation workflow that downloads APKs and executes post-install commands.

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5c2d66fa08325aec75b784c24d41b