### PR TITLE
Add dynamic MDM kit installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A web-based tool for installing Mobile Device Management (MDM) applications on A
 ## Features
 
 - 🔌 Direct USB connection to Android devices
-- 📱 Pre-configured MDM application profiles (Workspace ONE, Intune, Meraki)
+- 📱 Dynamic MDM kit grid sourced from `/apk`
 - 📦 Custom APK installation support
 - 🚀 Batch APK installation
 - 📊 Real-time installation progress tracking
@@ -50,10 +50,7 @@ Visit: [https://your-username.github.io/jtechmdminstaller](https://your-username
    - Authorize the connection on your device
 
 2. **Select MDM Applications**
-   - Choose from pre-configured MDM apps:
-     - VMware Workspace ONE
-     - Microsoft Intune
-     - Cisco Meraki SM
+   - Choose from available MDM kits discovered under `/apk`
    - Or upload custom APK files
 
 3. **Install Applications**
@@ -71,16 +68,19 @@ git clone https://github.com/your-username/jtechmdminstaller.git
 cd jtechmdminstaller
 ```
 
-2. Serve the files locally (requires HTTPS for WebUSB):
+2. Start the development server (exposes the `/api/apks` endpoint):
 ```bash
-# Using Python
-python -m http.server 8000
-
-# Or using Node.js
-npx http-server -S -C cert.pem
+npm start
+# or
+node server.js
 ```
 
-3. Access via `https://localhost:8000`
+3. Access via `http://localhost:8000`
+
+4. For HTTPS (required by WebUSB outside `localhost`):
+```bash
+npm run serve-https
+```
 
 ### Project Structure
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -255,7 +255,7 @@ body {
     background: linear-gradient(135deg, var(--card-gradient-start), var(--card-gradient-end));
     border: 2px solid var(--border-color);
     border-radius: 0.5rem;
-    cursor: pointer;
+    cursor: default;
     transition: all 0.2s;
 }
 
@@ -270,6 +270,11 @@ body {
     background: linear-gradient(135deg, var(--success-gradient-start), var(--success-gradient-end));
     color: white;
     border-color: var(--success-color);
+}
+
+.app-item .install-btn {
+    margin-top: 0.5rem;
+    width: 100%;
 }
 
 .app-icon {

--- a/index.html
+++ b/index.html
@@ -56,57 +56,7 @@
             <!-- APK Installation Card -->
             <div class="card install-card" id="installCard">
                 <h2>Install MDM Applications</h2>
-                
-                <!-- Pre-configured MDM APKs -->
-                <div class="mdm-apps">
-                    <h3>Quick Install</h3>
-                    <div class="app-grid" id="presetApps">
-                        <button class="app-item" data-apk="workspace-one">
-                            <div class="app-icon">WS1</div>
-                            <span>Workspace ONE</span>
-                        </button>
-                        <button class="app-item" data-apk="intune">
-                            <div class="app-icon">MS</div>
-                            <span>Microsoft Intune</span>
-                        </button>
-                        <button class="app-item" data-apk="meraki">
-                            <div class="app-icon">SM</div>
-                            <span>Meraki SM</span>
-                        </button>
-                        <button class="app-item" data-apk="custom">
-                            <div class="app-icon">+</div>
-                            <span>Custom APK</span>
-                        </button>
-                    </div>
-                </div>
-
-                <!-- Custom APK Upload -->
-                <div class="upload-section hidden" id="uploadSection">
-                    <div class="upload-area" id="uploadArea">
-                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
-                            <polyline points="17 8 12 3 7 8"></polyline>
-                            <line x1="12" y1="3" x2="12" y2="15"></line>
-                        </svg>
-                        <p>Drop APK files here or click to browse</p>
-                        <input type="file" id="apkInput" accept=".apk" multiple hidden>
-                    </div>
-                </div>
-
-                <!-- APK Queue -->
-                <div class="apk-queue hidden" id="apkQueue">
-                    <h3>Installation Queue</h3>
-                    <div class="queue-list" id="queueList"></div>
-                    <div class="queue-actions">
-                        <button class="btn btn-secondary" id="clearQueueBtn">Clear All</button>
-                        <button class="btn btn-primary" id="installBtn">
-                            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <path d="M19 11H5m14 0l-7 7m7-7l-7-7"></path>
-                            </svg>
-                            Install All
-                        </button>
-                    </div>
-                </div>
+                <div class="app-grid" id="kitsGrid"></div>
             </div>
 
             <!-- Progress Card -->

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Web-based MDM APK installer for Android devices using WebUSB",
   "main": "index.html",
   "scripts": {
-    "start": "python3 -m http.server 8000",
-    "serve": "npx http-server -p 8000",
+    "start": "node server.js",
+    "dev": "node server.js",
     "serve-https": "npx http-server -S -C cert.pem -p 8443"
   },
   "keywords": [

--- a/server.js
+++ b/server.js
@@ -30,7 +30,7 @@ const server = http.createServer((req, res) => {
       }
 
       const apps = entries
-        .filter(entry => entry.isDirectory())
+        .filter(entry => entry.isDirectory() && entry.name !== 'blog')
         .map(dir => {
           const dirPath = path.join('./apk', dir.name);
 


### PR DESCRIPTION
## Summary
- Replace static MDM installer with dynamic kit grid sourced from `/api/apks`
- Add install workflow that downloads APKs and runs per-kit command scripts
- Style app grid cards and full-width install buttons
- Document dynamic kit discovery in README
- Serve app with `node server.js` to expose `/api/apks`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5c2d66fa08325aec75b784c24d41b