### PR TITLE
Add welcome modal and step-by-step tutorial

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -636,6 +636,27 @@ body {
     margin-top: 1.5rem;
 }
 
+.tutorial-step {
+    display: none;
+}
+
+.tutorial-step.active {
+    display: block;
+}
+
+.tutorial-navigation {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 1.5rem;
+}
+
+.modal-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
 .footer-text {
     margin-top: 2rem;
     padding-top: 1rem;

--- a/js/app.js
+++ b/js/app.js
@@ -11,6 +11,8 @@ class JTechMDMInstaller {
         this.apkQueue = [];
         this.availableApks = [];
         this.commandHistory = [];
+        this.currentTutorialStep = 0;
+        this.tutorialSteps = [];
     }
 
     async init() {
@@ -70,6 +72,7 @@ class JTechMDMInstaller {
 
         // Modals
         document.getElementById('helpBtn')?.addEventListener('click', () => {
+            this.showTutorialStep(0);
             document.getElementById('helpModal').classList.remove('hidden');
         });
 
@@ -85,6 +88,28 @@ class JTechMDMInstaller {
             document.getElementById('aboutModal').classList.add('hidden');
         });
 
+        document.getElementById('skipTutorialBtn')?.addEventListener('click', () => {
+            document.getElementById('welcomeModal')?.classList.add('hidden');
+        });
+
+        document.getElementById('startTutorialBtn')?.addEventListener('click', () => {
+            document.getElementById('welcomeModal')?.classList.add('hidden');
+            this.showTutorialStep(0);
+            document.getElementById('helpModal')?.classList.remove('hidden');
+        });
+
+        document.getElementById('closeWelcomeBtn')?.addEventListener('click', () => {
+            document.getElementById('welcomeModal')?.classList.add('hidden');
+        });
+
+        document.getElementById('nextStepBtn')?.addEventListener('click', () => {
+            this.showTutorialStep(this.currentTutorialStep + 1);
+        });
+
+        document.getElementById('prevStepBtn')?.addEventListener('click', () => {
+            this.showTutorialStep(this.currentTutorialStep - 1);
+        });
+
         // Close modals on outside click
         document.querySelectorAll('.modal').forEach(modal => {
             modal.addEventListener('click', (e) => {
@@ -93,6 +118,38 @@ class JTechMDMInstaller {
                 }
             });
         });
+    }
+
+    showTutorialStep(index) {
+        this.tutorialSteps = Array.from(document.querySelectorAll('.tutorial-step'));
+        if (this.tutorialSteps.length === 0) return;
+
+        if (index >= this.tutorialSteps.length) {
+            document.getElementById('helpModal')?.classList.add('hidden');
+            return;
+        }
+
+        if (index < 0) index = 0;
+
+        this.tutorialSteps.forEach((step, i) => {
+            step.classList.toggle('active', i === index);
+        });
+        this.currentTutorialStep = index;
+
+        const prevBtn = document.getElementById('prevStepBtn');
+        const nextBtn = document.getElementById('nextStepBtn');
+
+        if (prevBtn) {
+            prevBtn.disabled = index === 0;
+        }
+
+        if (nextBtn) {
+            if (index === this.tutorialSteps.length - 1) {
+                nextBtn.textContent = 'Finish';
+            } else {
+                nextBtn.textContent = 'Next';
+            }
+        }
     }
 
     async handleConnect() {
@@ -668,4 +725,5 @@ document.addEventListener('DOMContentLoaded', async () => {
     await app.init();
     // Make UIManager globally accessible for modal buttons
     window.uiManager = app.uiManager;
+    document.getElementById('welcomeModal')?.classList.remove('hidden');
 });

--- a/template.html
+++ b/template.html
@@ -55,7 +55,7 @@
             </div>
 
             <!-- APK Installation Card -->
-            <div class="card install-card" id="installCard">
+            <div class="card install-card hidden" id="installCard">
                 <h2>Install MDM Applications</h2>
                 <div class="app-grid" id="kitsGrid"></div>
             </div>
@@ -113,7 +113,24 @@
         </div>
     </main>
 
-    <!-- Help Modal -->
+    <!-- Welcome Modal -->
+    <div class="modal hidden" id="welcomeModal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h2>Welcome to JTech MDM Installer</h2>
+                <button class="modal-close" id="closeWelcomeBtn">&times;</button>
+            </div>
+            <div class="modal-body">
+                <p>Let's start by connecting your device.</p>
+                <div class="modal-actions">
+                    <button class="btn btn-secondary" id="skipTutorialBtn">Skip Tutorial</button>
+                    <button class="btn btn-primary" id="startTutorialBtn">Start Tutorial</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Tutorial Modal -->
     <div class="modal hidden" id="helpModal">
         <div class="modal-content">
             <div class="modal-header">
@@ -121,37 +138,41 @@
                 <button class="modal-close" id="closeHelpBtn">&times;</button>
             </div>
             <div class="modal-body">
-                <ol>
-                    <li>
-                        <strong>Enable Developer Options on your Android device:</strong>
+                <div class="tutorial-container" id="tutorialContainer">
+                    <div class="tutorial-step active">
+                        <h3>Step 1: Enable Developer Options</h3>
                         <ul>
                             <li>Go to Settings → About Phone</li>
                             <li>Tap "Build Number" 7 times</li>
                         </ul>
-                    </li>
-                    <li>
-                        <strong>Enable USB Debugging:</strong>
+                    </div>
+                    <div class="tutorial-step">
+                        <h3>Step 2: Enable USB Debugging</h3>
                         <ul>
                             <li>Go to Settings → Developer Options</li>
                             <li>Enable "USB Debugging"</li>
                         </ul>
-                    </li>
-                    <li>
-                        <strong>Connect your device:</strong>
+                    </div>
+                    <div class="tutorial-step">
+                        <h3>Step 3: Connect Your Device</h3>
                         <ul>
                             <li>Connect via USB cable</li>
-                            <li>Click "Connect Device" button</li>
-                            <li>Authorize on your device when prompted</li>
+                            <li>Click "Connect Device" in this app</li>
+                            <li>If prompted on your device, tap "Allow" to authorize the connection</li>
                         </ul>
-                    </li>
-                    <li>
-                        <strong>Install MDM apps:</strong>
+                    </div>
+                    <div class="tutorial-step">
+                        <h3>Step 4: Install MDM Apps</h3>
                         <ul>
                             <li>Select from quick install options or upload custom APKs</li>
                             <li>Click "Install All" to begin</li>
                         </ul>
-                    </li>
-                </ol>
+                    </div>
+                </div>
+                <div class="tutorial-navigation">
+                    <button class="btn btn-secondary" id="prevStepBtn">Previous</button>
+                    <button class="btn btn-primary" id="nextStepBtn">Next</button>
+                </div>
                 <div class="warning">
                     <strong>Note:</strong> This tool requires Chrome or Edge browser with WebUSB support.
                 </div>


### PR DESCRIPTION
## Summary
- Show a welcome modal on load with options to skip or start a tutorial.
- Add a card-based tutorial that guides users through enabling developer options, USB debugging, connecting, and installing MDM apps.
- Hide installation features until a device is connected and provide JS logic for navigating tutorial steps.

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5cdc2b1a483258b3bdb2d9f40d307