### PR TITLE
feat: replace MDM grid with Glide.js carousel

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -243,12 +243,19 @@ body {
     cursor: not-allowed;
 }
 
-/* MDM Apps Grid */
-.app-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-    gap: 1rem;
+/* MDM Apps Slider */
+#kitsGlide {
     margin-bottom: 1.5rem;
+}
+
+#kitsGlide .glide__slides {
+    list-style: none;
+}
+
+#kitsGlide .glide__slide {
+    display: flex;
+    justify-content: center;
+    padding: 0 0.5rem;
 }
 
 .app-item {
@@ -693,10 +700,6 @@ body {
         gap: 0.5rem;
     }
 
-    .app-grid {
-        grid-template-columns: repeat(2, 1fr);
-    }
-
     .queue-actions {
         flex-direction: column;
         gap: 1rem;
@@ -709,9 +712,6 @@ body {
 }
 
 @media (max-width: 480px) {
-    .app-grid {
-        grid-template-columns: 1fr;
-    }
 }
 
 /* Console Styles */

--- a/js/app.js
+++ b/js/app.js
@@ -13,6 +13,7 @@ class JTechMDMInstaller {
         this.commandHistory = [];
         this.currentTutorialStep = 0;
         this.tutorialSteps = [];
+        this.glide = null;
     }
 
     async init() {
@@ -249,20 +250,34 @@ class JTechMDMInstaller {
         grid.innerHTML = '';
 
         this.availableApks.forEach((apk) => {
-            const item = document.createElement('div');
-            item.className = 'app-item';
-            item.innerHTML = `
-                <div class="app-icon">
-                    ${apk.image ? `<img src="${apk.image}" alt="${apk.name}">` : ''}
+            const slide = document.createElement('li');
+            slide.className = 'glide__slide';
+            slide.innerHTML = `
+                <div class="app-item">
+                    <div class="app-icon">
+                        ${apk.image ? `<img src="${apk.image}" alt="${apk.name}">` : ''}
+                    </div>
+                    <span>${apk.name}</span>
+                    <button class="btn btn-primary install-btn">Install</button>
                 </div>
-                <span>${apk.name}</span>
-                <button class="btn btn-primary install-btn">Install</button>
             `;
 
-            item.querySelector('.install-btn').addEventListener('click', () => this.installKit(apk));
+            slide.querySelector('.install-btn').addEventListener('click', () => this.installKit(apk));
 
-            grid.appendChild(item);
+            grid.appendChild(slide);
         });
+
+        if (this.glide) {
+            this.glide.destroy();
+        }
+
+        this.glide = new Glide('#kitsGlide', {
+            type: 'carousel',
+            perView: 5,
+            focusAt: 'center',
+            gap: 24
+        });
+        this.glide.mount();
     }
 
     getPresetApkInfo(type) {

--- a/template.html
+++ b/template.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>JTech MDM Installer - Android Device Management</title>
     <link rel="stylesheet" href="css/styles.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@glidejs/glide/dist/css/glide.core.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@glidejs/glide/dist/css/glide.theme.min.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
@@ -58,7 +60,15 @@
             <!-- APK Installation Card -->
             <div class="card install-card hidden" id="installCard">
                 <h2>Install MDM Applications</h2>
-                <div class="app-grid" id="kitsGrid"></div>
+                <div class="glide" id="kitsGlide">
+                    <div class="glide__track" data-glide-el="track">
+                        <ul class="glide__slides" id="kitsGrid"></ul>
+                    </div>
+                    <div class="glide__arrows" data-glide-el="controls">
+                        <button class="glide__arrow glide__arrow--left btn btn-secondary" data-glide-dir="<">Prev</button>
+                        <button class="glide__arrow glide__arrow--right btn btn-secondary" data-glide-dir=">">Next</button>
+                    </div>
+                </div>
             </div>
 
             <!-- Progress Card -->
@@ -178,6 +188,7 @@
     </div>
 
     <script src="js/webadb.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@glidejs/glide/dist/glide.min.js"></script>
     <script src="js/app.js" type="module"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Replace static MDM app grid with Glide.js horizontal carousel
- Initialize slider in JavaScript and style slides for five-per-view layout
- Load Glide.js assets in template

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b5d342c1b483258867741a6dc23824