### PR TITLE
Improve kit card layout and navigation

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -12,7 +12,7 @@
 
 .swiper-slide {
   opacity: 0.55;
-  width: 300px; /* fit within parent card without clipping */
+  width: 260px; /* fit within parent card without clipping */
 }
 
 .swiper-slide-prev,
@@ -30,9 +30,9 @@
   border-radius: 16px;
   padding: 20px;
   width: 100%;
-  min-width: 260px;
-  max-width: 300px;
-  min-height: 340px; /* slightly shorter to avoid clipping */
+  min-width: 240px;
+  max-width: 260px;
+  min-height: 300px; /* slightly shorter to avoid clipping */
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -101,6 +101,13 @@
   margin: 0;
   cursor: pointer;
   line-height: 1;
+}
+
+/* reset old install button styles so gradient fills entire half */
+.action-bar .install-btn,
+.action-bar .info-btn {
+  margin-top: 0;
+  width: auto;
 }
 
 .install-btn {

--- a/css/styles.css
+++ b/css/styles.css
@@ -140,9 +140,9 @@ body {
     background-clip: text;
 }
 
-/* ensure swiper cards can fully display within the install card */
+/* ensure swiper cards stay within the install card bounds */
 .install-card {
-    overflow: visible;
+    overflow: hidden;
 }
 
 /* Device Status */

--- a/js/cards.js
+++ b/js/cards.js
@@ -36,8 +36,8 @@ export function renderKits(apks, { onInstall, onInfo } = {}) {
         slidesPerView: 'auto',
         slideToClickedSlide: true,
         spaceBetween: 40,
-        slidesOffsetBefore: 0,
-        slidesOffsetAfter: 0,
+        slidesOffsetBefore: 80,
+        slidesOffsetAfter: 80,
         initialSlide: startIndex >= 0 ? startIndex : 0,
         coverflowEffect: {
             rotate: 8,


### PR DESCRIPTION
## Summary
- allow scrolling to final kit card by adding swiper offsets
- prevent kit cards from overflowing their container and shrink their footprint
- fix install action-bar button spacing so purple gradient fills the left half

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b61e66017c8325b1ec0a112b7644a9