### PR TITLE
style: stretch card images and normalize action buttons

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -33,15 +33,13 @@
   background: linear-gradient(180deg, #141a28 0%, #0f172a 100%);
   color: #e5e7eb;
   border-radius: 16px;
-  padding: 20px;
   width: 100%;
   min-width: 240px;
   max-width: 260px;
   min-height: 300px; /* slightly shorter to avoid clipping */
   display: flex;
   flex-direction: column;
-  justify-content: space-between;
-  text-align: center;
+  overflow: hidden;
   border: 1px solid rgba(148,163,184,0.12);
   box-shadow: 0 10px 24px rgba(2,6,23,0.35);
   transition: transform .22s ease, box-shadow .22s ease, filter .22s ease;
@@ -60,18 +58,31 @@
 .app-item {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 8px;
+  height: 100%;
+}
+
+.app-icon {
+  flex: 0 0 50%;
+  width: 100%;
+  height: 50%;
+  overflow: hidden;
 }
 
 .app-icon img {
-  width: 100px;
-  height: 100px;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
-  background-color: #fff;
-  margin-top: 6px;
-  border-radius: 14px;
+  display: block;
   filter: drop-shadow(0 2px 6px rgba(0,0,0,0.35));
+}
+
+.app-content {
+  flex: 1 0 50%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  text-align: center;
+  padding: 16px;
 }
 
 .app-title {
@@ -79,12 +90,14 @@
   letter-spacing: .2px;
   margin: 4px 0 8px;
   color: #e5e7eb;
+  font-family: 'Inter', sans-serif;
+  font-size: 1rem;
 }
 
 .action-bar {
-  width: 50%;
+  width: 100%;
   height: 36px;
-  margin: 16px auto 0;
+  margin-top: 16px;
   display: flex;
   align-items: stretch;
   border-radius: 8px; /* box shape */
@@ -102,7 +115,8 @@
   align-items: center;
   justify-content: center;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
+  font-family: 'Inter', sans-serif;
   border: 0;
   margin: 0;
   cursor: pointer;

--- a/js/cards.js
+++ b/js/cards.js
@@ -12,10 +12,12 @@ export function renderKits(apks, { onInstall, onInfo } = {}) {
                 <div class="app-icon">
                     ${apk.image ? `<img src="${apk.image}" alt="${apk.title}">` : ''}
                 </div>
-                <span class="app-title">${apk.title}</span>
-                <div class="action-bar">
-                    <button class="install-btn">Install</button>
-                    <button class="info-btn">View Info</button>
+                <div class="app-content">
+                    <span class="app-title">${apk.title}</span>
+                    <div class="action-bar">
+                        <button class="install-btn">Install</button>
+                        <button class="info-btn">View Info</button>
+                    </div>
                 </div>
             </div>
         `;


### PR DESCRIPTION
## Summary
- Display card images in a dedicated top-half container
- Fill card images and widen action bar to full card width
- Normalize Inter font for card titles and buttons

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b63c28eb7483259f3b4a49c620f49a