### PR TITLE
Style card action buttons

### DIFF
--- a/css/cards.css
+++ b/css/cards.css
@@ -94,33 +94,29 @@
   font-size: 1rem;
 }
 
+
 .action-bar {
   width: 100%;
-  height: 36px;
   margin-top: 16px;
   display: flex;
-  align-items: stretch;
-  border-radius: 8px; /* box shape */
-  overflow: hidden;
-  border: 1px solid rgba(99,102,241,0.28);
-  background: #0b1221;
-  padding: 0;
+  gap: 8px;
 }
 
 .action-bar button {
   flex: 1;
-  width: 50%;
-  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
   font-weight: 600;
   font-size: 0.8rem;
   font-family: 'Inter', sans-serif;
-  border: 0;
-  margin: 0;
+  border: 1px solid rgba(99,102,241,0.28);
+  border-radius: 9999px;
+  padding: 0.5rem 0;
   cursor: pointer;
   line-height: 1;
+  white-space: nowrap;
+  background: #0b1221;
 }
 
 /* reset old install button styles so gradient fills entire half */
@@ -141,7 +137,6 @@
 .info-btn {
   background: rgba(99,102,241,0.10);
   color: #c7d2fe;
-  border-left: 1px solid rgba(99,102,241,0.28);
 }
 
 .info-btn:hover {


### PR DESCRIPTION
## Summary
- Make install card action buttons pill-shaped and evenly spaced
- Ensure "View Info" text remains on a single line

## Testing
- `npm test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68b644121ecc8325837ec40be70667c9