### PR TITLE
Handle tab changes for stable ADB sessions

### DIFF
--- a/js/connections.js
+++ b/js/connections.js
@@ -102,7 +102,7 @@ export class AdbConnection {
         }
     }
 
-    async disconnect() {
+    async disconnect(clearCache = true) {
         if (this.adb) {
             try {
                 await this.adb.close?.();
@@ -115,7 +115,9 @@ export class AdbConnection {
             this.webusb = null;
             this.adb = null;
             this.device = null;
-            localStorage.removeItem('adbDevice');
+            if (clearCache) {
+                localStorage.removeItem('adbDevice');
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Keep ADB connection state when switching between MDM and console tabs
- Retry auto-connection and suppress noisy errors during background reconnects
- Allow disconnection without clearing cached device info for seamless tab switching

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b64dfdffa48325a41e82bb41f6550c