### PR TITLE
Fix YAML syntax in GitHub Pages workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
       - name: List files (debug)
         run: ls -la "${{ steps.detect.outputs.dir }}"
 
-      - name: Preflight: ensure index.html exists
+      - name: "Preflight: ensure index.html exists"
         run: |
           if [ ! -f "${{ steps.detect.outputs.dir }}/index.html" ]; then
             echo "ERROR: No index.html found in ${{ steps.detect.outputs.dir }}."


### PR DESCRIPTION
## Summary
- quote step name containing colon to produce valid YAML in GitHub Pages workflow

## Testing
- `npm test` (fails: missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b725c56a288325920183ba028b8619