### PR TITLE
Fix GitHub Pages workflow to detect docs output directory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,14 +52,14 @@ jobs:
       - name: Detect output directory
         id: detect
         run: |
-          for d in dist build out .next/out .output/public public; do
+          for d in dist build out .next/out .output/public public docs; do
             if [ -d "$d" ]; then
               echo "dir=$d" >> $GITHUB_OUTPUT
               echo "Detected output dir: $d"
               exit 0
             fi
           done
-          echo "ERROR: Could not find a build output directory (looked for dist, build, out, .next/out, .output/public, public)."
+          echo "ERROR: Could not find a build output directory (looked for dist, build, out, .next/out, .output/public, public, docs)."
           exit 1
 
       - name: List files (debug)


### PR DESCRIPTION
## Summary
- add `docs` to build output detection list in GitHub Pages workflow

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7269a90d4832589e93bf7537fab37