### PR TITLE
Reduce console output height

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -884,8 +884,8 @@ body.scaled {
     border: 2px solid var(--border-color);
     border-radius: 0.5rem;
     padding: 1rem;
-    min-height: 400px;
-    max-height: 600px;
+    min-height: 300px;
+    max-height: 500px;
     overflow-y: auto;
     overflow-x: auto;
     font-family: 'Courier New', monospace;


### PR DESCRIPTION
## Summary
- Reduce default height of ADB console output area for a more compact view

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b87bc99df083259d2e82e35d8904ec