### PR TITLE
Add JTech favicon metadata

### DIFF
--- a/console.html
+++ b/console.html
@@ -9,6 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/icon.png">
+    <meta property="og:image" content="/icon.png">
 </head>
 <body>
     <header class="header">

--- a/template.html
+++ b/template.html
@@ -11,6 +11,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/png" href="/icon.png">
+    <meta property="og:image" content="/icon.png">
 </head>
 <body>
     <header class="header">


### PR DESCRIPTION
## Summary
- reference JTech icon as site favicon and Open Graph image

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b8dffa63a48325ba0946833d594f19