### PR TITLE
Handle account conflicts during device owner setup

### DIFF
--- a/docs/js/adb/account-utils.js
+++ b/docs/js/adb/account-utils.js
@@ -1,0 +1,116 @@
+export async function isDeviceRooted(adb) {
+  if (!adb) return false;
+  try {
+    const outputs = [];
+    try {
+      const out = await adb.executeShellCommand('which su');
+      if (out && out.trim().includes('/su') && !/not found|permission denied/i.test(out)) outputs.push(out);
+    } catch {}
+    try {
+      const out = await adb.executeShellCommand('whoami');
+      if (out && out.trim().toLowerCase() === 'root' && !/permission denied/i.test(out)) outputs.push(out);
+    } catch {}
+    try {
+      const out = await adb.executeShellCommand('pm list packages');
+      if (out && /com\.topjohnwu\.magisk|eu\.chainfire\.supersu/i.test(out)) outputs.push(out);
+    } catch {}
+    return outputs.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function isAndroid14OrHigher(adb) {
+  if (!adb) return false;
+  try {
+    const apiLevel = await adb.executeShellCommand('getprop ro.build.version.sdk');
+    const level = parseInt(apiLevel.trim(), 10);
+    return !isNaN(level) && level >= 34;
+  } catch {
+    return false;
+  }
+}
+
+export async function deviceHasAccounts(adb) {
+  if (!adb) return false;
+  const outputs = [];
+  const cmds = [
+    'cmd account list --user 0',
+    'cmd account list',
+    'dumpsys account',
+    'cmd accounts list',
+  ];
+  for (const cmd of cmds) {
+    try {
+      const out = await adb.executeShellCommand(cmd);
+      if (out && out.trim()) outputs.push(out);
+    } catch {}
+  }
+  const out = outputs.join('\n\n').trim();
+  if (!out) return false;
+  const lower = out.toLowerCase();
+  if (/accounts?\s*:\s*(\d+)/.test(lower)) {
+    const n = parseInt(RegExp.$1, 10);
+    if (!isNaN(n)) return n > 0;
+  }
+  if (/account\s*\{?\s*name\s*=/.test(lower)) return true;
+  if (/type=/.test(lower) && /name=/.test(lower)) return true;
+  if (/@[a-z0-9._%+-]+(?:\.[a-z0-9._%+-]+)+/i.test(out)) return true;
+  if (/com\.google|whatsapp|facebook|telegram|samsung|microsoft|work|exchange|corp/i.test(out)) return true;
+  if (/no accounts/i.test(lower)) return false;
+  if (/accounts?:/.test(out) && /accounts?:[^\n]*\n[ \t]+\S+/i.test(out)) return true;
+  return false;
+}
+
+export async function disableAccountApps(adb) {
+  if (!adb) return [];
+  const disabled = new Set();
+  const run = async pkg => {
+    try {
+      await adb.executeShellCommand(`pm disable-user --user 0 ${pkg}`);
+      disabled.add(pkg);
+      console.log('disabled', pkg);
+    } catch (e) {
+      console.log('failed to disable', pkg);
+    }
+  };
+  const manualPkgs = [
+    'com.microsoft.office.officehubrow',
+    'com.microsoft.office.word',
+    'com.microsoft.office.excel',
+    'com.microsoft.office.outlook',
+    'com.microsoft.office.powerpoint',
+  ];
+  for (const pkg of manualPkgs) {
+    await run(pkg);
+  }
+  try {
+    const out = await adb.executeShellCommand('dumpsys account');
+    const re = /ComponentInfo\{([^\/}]+)\/[^}]+\}/g;
+    let m;
+    while ((m = re.exec(out))) {
+      await run(m[1]);
+    }
+  } catch (e) {
+    console.log('dumpsys account error', e?.message || e);
+  }
+  return Array.from(disabled);
+}
+
+export async function reenablePackages(adb, packages) {
+  if (!adb || !packages?.length) return;
+  console.log('reenablePackages', packages);
+  for (const pkg of packages) {
+    try {
+      await adb.executeShellCommand(`pm enable ${pkg}`);
+      console.log('reenabled', pkg);
+    } catch (e) {
+      console.log('failed to reenable', pkg);
+    }
+  }
+}
+
+export async function runShellCommand(adb, cmd) {
+  const c = Array.isArray(cmd) ? cmd.join(' ') : cmd;
+  return await adb.executeShellCommand(c);
+}

--- a/docs/js/apps.js
+++ b/docs/js/apps.js
@@ -3,6 +3,7 @@ import { ApkInstaller } from './adb/apk-installer.js';
 import { UIManager } from './ui/ui-manager.js';
 import KITS from './data/kits.js';
 import { renderKits } from './ui/cards.js';
+import { deviceHasAccounts, disableAccountApps, reenablePackages } from './adb/account-utils.js';
 
 class JTechMDMInstaller {
     constructor() {
@@ -520,11 +521,7 @@ class JTechMDMInstaller {
                                         await new Promise(resolve => setTimeout(resolve, 3000));
                                     }
 
-                                    this.uiManager.logToConsole(`Running: ${command}`, 'info');
-                                    const result = await this.adbConnection.executeShellCommand(command);
-                                    if (result.trim()) {
-                                        this.uiManager.logToConsole(`Command output: ${result.trim()}`, 'info');
-                                    }
+                                    await this.executeCommandWithAccountCheck(command);
 
                                     await new Promise(resolve => setTimeout(resolve, 500));
 
@@ -597,11 +594,7 @@ class JTechMDMInstaller {
                             await new Promise(resolve => setTimeout(resolve, 3000));
                         }
 
-                        this.uiManager.logToConsole(`Running: ${command}`, 'info');
-                        const result = await this.adbConnection.executeShellCommand(command);
-                        if (result.trim()) {
-                            this.uiManager.logToConsole(`Command output: ${result.trim()}`, 'info');
-                        }
+                        await this.executeCommandWithAccountCheck(command);
 
                         await new Promise(resolve => setTimeout(resolve, 500));
                     } catch (cmdError) {
@@ -616,10 +609,38 @@ class JTechMDMInstaller {
             this.uiManager.logToConsole(`Successfully installed ${apk.title || apk.name}`, 'success');
             this.uiManager.showSuccess(`${apk.title || apk.name} installed successfully`);
         } catch (error) {
-            this.uiManager.updateProgress(100, 'Installation failed');
-            this.uiManager.logToConsole(`Failed to install ${apk.title || apk.name}: ${error.message}`, 'error');
-            this.uiManager.showError(`Failed to install ${apk.title || apk.name}: ${error.message}`);
+        this.uiManager.updateProgress(100, 'Installation failed');
+        this.uiManager.logToConsole(`Failed to install ${apk.title || apk.name}: ${error.message}`, 'error');
+        this.uiManager.showError(`Failed to install ${apk.title || apk.name}: ${error.message}`);
+    }
+}
+
+    async executeCommandWithAccountCheck(command) {
+        this.uiManager.logToConsole(`Running: ${command}`, 'info');
+        let result = await this.adbConnection.executeShellCommand(command);
+
+        if (command.includes('dpm set-device-owner') && !/success/i.test(result)) {
+            const hasAccounts = /account/i.test(result) || await deviceHasAccounts(this.adbConnection);
+            if (hasAccounts) {
+                this.uiManager.logToConsole('Accounts detected - temporarily disabling account apps...', 'warning');
+                const disabled = await disableAccountApps(this.adbConnection);
+                try {
+                    result = await this.adbConnection.executeShellCommand(command);
+                } finally {
+                    await reenablePackages(this.adbConnection, disabled);
+                }
+                if (!/success/i.test(result)) {
+                    throw new Error('accounts found - please go into settings>accounts>remove all accounts - then reboot and try again.');
+                }
+            } else {
+                throw new Error(result.trim() || 'Command failed');
+            }
         }
+
+        if (result.trim()) {
+            this.uiManager.logToConsole(`Command output: ${result.trim()}`, 'info');
+        }
+        return result;
     }
 
     formatFileSize(bytes) {

--- a/js/adb/account-utils.js
+++ b/js/adb/account-utils.js
@@ -1,0 +1,116 @@
+export async function isDeviceRooted(adb) {
+  if (!adb) return false;
+  try {
+    const outputs = [];
+    try {
+      const out = await adb.executeShellCommand('which su');
+      if (out && out.trim().includes('/su') && !/not found|permission denied/i.test(out)) outputs.push(out);
+    } catch {}
+    try {
+      const out = await adb.executeShellCommand('whoami');
+      if (out && out.trim().toLowerCase() === 'root' && !/permission denied/i.test(out)) outputs.push(out);
+    } catch {}
+    try {
+      const out = await adb.executeShellCommand('pm list packages');
+      if (out && /com\.topjohnwu\.magisk|eu\.chainfire\.supersu/i.test(out)) outputs.push(out);
+    } catch {}
+    return outputs.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export async function isAndroid14OrHigher(adb) {
+  if (!adb) return false;
+  try {
+    const apiLevel = await adb.executeShellCommand('getprop ro.build.version.sdk');
+    const level = parseInt(apiLevel.trim(), 10);
+    return !isNaN(level) && level >= 34;
+  } catch {
+    return false;
+  }
+}
+
+export async function deviceHasAccounts(adb) {
+  if (!adb) return false;
+  const outputs = [];
+  const cmds = [
+    'cmd account list --user 0',
+    'cmd account list',
+    'dumpsys account',
+    'cmd accounts list',
+  ];
+  for (const cmd of cmds) {
+    try {
+      const out = await adb.executeShellCommand(cmd);
+      if (out && out.trim()) outputs.push(out);
+    } catch {}
+  }
+  const out = outputs.join('\n\n').trim();
+  if (!out) return false;
+  const lower = out.toLowerCase();
+  if (/accounts?\s*:\s*(\d+)/.test(lower)) {
+    const n = parseInt(RegExp.$1, 10);
+    if (!isNaN(n)) return n > 0;
+  }
+  if (/account\s*\{?\s*name\s*=/.test(lower)) return true;
+  if (/type=/.test(lower) && /name=/.test(lower)) return true;
+  if (/@[a-z0-9._%+-]+(?:\.[a-z0-9._%+-]+)+/i.test(out)) return true;
+  if (/com\.google|whatsapp|facebook|telegram|samsung|microsoft|work|exchange|corp/i.test(out)) return true;
+  if (/no accounts/i.test(lower)) return false;
+  if (/accounts?:/.test(out) && /accounts?:[^\n]*\n[ \t]+\S+/i.test(out)) return true;
+  return false;
+}
+
+export async function disableAccountApps(adb) {
+  if (!adb) return [];
+  const disabled = new Set();
+  const run = async pkg => {
+    try {
+      await adb.executeShellCommand(`pm disable-user --user 0 ${pkg}`);
+      disabled.add(pkg);
+      console.log('disabled', pkg);
+    } catch (e) {
+      console.log('failed to disable', pkg);
+    }
+  };
+  const manualPkgs = [
+    'com.microsoft.office.officehubrow',
+    'com.microsoft.office.word',
+    'com.microsoft.office.excel',
+    'com.microsoft.office.outlook',
+    'com.microsoft.office.powerpoint',
+  ];
+  for (const pkg of manualPkgs) {
+    await run(pkg);
+  }
+  try {
+    const out = await adb.executeShellCommand('dumpsys account');
+    const re = /ComponentInfo\{([^\/}]+)\/[^}]+\}/g;
+    let m;
+    while ((m = re.exec(out))) {
+      await run(m[1]);
+    }
+  } catch (e) {
+    console.log('dumpsys account error', e?.message || e);
+  }
+  return Array.from(disabled);
+}
+
+export async function reenablePackages(adb, packages) {
+  if (!adb || !packages?.length) return;
+  console.log('reenablePackages', packages);
+  for (const pkg of packages) {
+    try {
+      await adb.executeShellCommand(`pm enable ${pkg}`);
+      console.log('reenabled', pkg);
+    } catch (e) {
+      console.log('failed to reenable', pkg);
+    }
+  }
+}
+
+export async function runShellCommand(adb, cmd) {
+  const c = Array.isArray(cmd) ? cmd.join(' ') : cmd;
+  return await adb.executeShellCommand(c);
+}

--- a/js/apps.js
+++ b/js/apps.js
@@ -3,6 +3,7 @@ import { ApkInstaller } from './adb/apk-installer.js';
 import { UIManager } from './ui/ui-manager.js';
 import KITS from './data/kits.js';
 import { renderKits } from './ui/cards.js';
+import { deviceHasAccounts, disableAccountApps, reenablePackages } from './adb/account-utils.js';
 
 class JTechMDMInstaller {
     constructor() {
@@ -520,11 +521,7 @@ class JTechMDMInstaller {
                                         await new Promise(resolve => setTimeout(resolve, 3000));
                                     }
 
-                                    this.uiManager.logToConsole(`Running: ${command}`, 'info');
-                                    const result = await this.adbConnection.executeShellCommand(command);
-                                    if (result.trim()) {
-                                        this.uiManager.logToConsole(`Command output: ${result.trim()}`, 'info');
-                                    }
+                                    await this.executeCommandWithAccountCheck(command);
 
                                     await new Promise(resolve => setTimeout(resolve, 500));
 
@@ -597,11 +594,7 @@ class JTechMDMInstaller {
                             await new Promise(resolve => setTimeout(resolve, 3000));
                         }
 
-                        this.uiManager.logToConsole(`Running: ${command}`, 'info');
-                        const result = await this.adbConnection.executeShellCommand(command);
-                        if (result.trim()) {
-                            this.uiManager.logToConsole(`Command output: ${result.trim()}`, 'info');
-                        }
+                        await this.executeCommandWithAccountCheck(command);
 
                         await new Promise(resolve => setTimeout(resolve, 500));
                     } catch (cmdError) {
@@ -616,10 +609,38 @@ class JTechMDMInstaller {
             this.uiManager.logToConsole(`Successfully installed ${apk.title || apk.name}`, 'success');
             this.uiManager.showSuccess(`${apk.title || apk.name} installed successfully`);
         } catch (error) {
-            this.uiManager.updateProgress(100, 'Installation failed');
-            this.uiManager.logToConsole(`Failed to install ${apk.title || apk.name}: ${error.message}`, 'error');
-            this.uiManager.showError(`Failed to install ${apk.title || apk.name}: ${error.message}`);
+        this.uiManager.updateProgress(100, 'Installation failed');
+        this.uiManager.logToConsole(`Failed to install ${apk.title || apk.name}: ${error.message}`, 'error');
+        this.uiManager.showError(`Failed to install ${apk.title || apk.name}: ${error.message}`);
+    }
+}
+
+    async executeCommandWithAccountCheck(command) {
+        this.uiManager.logToConsole(`Running: ${command}`, 'info');
+        let result = await this.adbConnection.executeShellCommand(command);
+
+        if (command.includes('dpm set-device-owner') && !/success/i.test(result)) {
+            const hasAccounts = /account/i.test(result) || await deviceHasAccounts(this.adbConnection);
+            if (hasAccounts) {
+                this.uiManager.logToConsole('Accounts detected - temporarily disabling account apps...', 'warning');
+                const disabled = await disableAccountApps(this.adbConnection);
+                try {
+                    result = await this.adbConnection.executeShellCommand(command);
+                } finally {
+                    await reenablePackages(this.adbConnection, disabled);
+                }
+                if (!/success/i.test(result)) {
+                    throw new Error('accounts found - please go into settings>accounts>remove all accounts - then reboot and try again.');
+                }
+            } else {
+                throw new Error(result.trim() || 'Command failed');
+            }
         }
+
+        if (result.trim()) {
+            this.uiManager.logToConsole(`Command output: ${result.trim()}`, 'info');
+        }
+        return result;
     }
 
     formatFileSize(bytes) {


### PR DESCRIPTION
## Summary
- add account utility helpers to detect accounts and disable/re-enable related packages
- retry `dpm set-device-owner` after temporarily disabling account apps and report a clear error if accounts remain

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8e55d02d88325a4f8cb1f4ae07175