### PR TITLE
Handle WebUSB claim interface error

### DIFF
--- a/docs/js/apps.js
+++ b/docs/js/apps.js
@@ -213,7 +213,11 @@ class JTechMDMInstaller {
         } catch (error) {
             console.error('Connection error:', error);
             if (!silent) {
-                this.uiManager.showError(`Connection failed: ${error.message}`);
+                if (error.message && error.message.includes('Unable to claim interface')) {
+                    this.uiManager.showError("Connection failed: another ADB server might already be using the device. Run `adb kill-server` in your command prompt and then retry.");
+                } else {
+                    this.uiManager.showError(`Connection failed: ${error.message}`);
+                }
             }
             const btn = document.getElementById('connectBtn');
             if (btn) btn.disabled = false;

--- a/js/apps.js
+++ b/js/apps.js
@@ -213,7 +213,11 @@ class JTechMDMInstaller {
         } catch (error) {
             console.error('Connection error:', error);
             if (!silent) {
-                this.uiManager.showError(`Connection failed: ${error.message}`);
+                if (error.message && error.message.includes('Unable to claim interface')) {
+                    this.uiManager.showError("Connection failed: another ADB server might already be using the device. Run `adb kill-server` in your command prompt and then retry.");
+                } else {
+                    this.uiManager.showError(`Connection failed: ${error.message}`);
+                }
             }
             const btn = document.getElementById('connectBtn');
             if (btn) btn.disabled = false;


### PR DESCRIPTION
## Summary
- Show clearer message when WebUSB connection fails due to an active ADB server

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8fb3c201c8325a312112e99cf8066