### PR TITLE
Fix favicon path

### DIFF
--- a/console.html
+++ b/console.html
@@ -9,8 +9,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="icon" type="image/png" href="/icon.png">
-    <meta property="og:image" content="/icon.png">
+    <link rel="icon" type="image/png" href="icon.png">
+    <meta property="og:image" content="icon.png">
 </head>
 <body>
     <header class="header">

--- a/js/page.js
+++ b/js/page.js
@@ -10,8 +10,8 @@ document.addEventListener('DOMContentLoaded', () => {
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-        <link rel="icon" type="image/png" href="/icon.png">
-        <meta property="og:image" content="/icon.png">
+        <link rel="icon" type="image/png" href="icon.png">
+        <meta property="og:image" content="icon.png">
     `;
     document.head.innerHTML = headContent;
 

--- a/template.html
+++ b/template.html
@@ -12,8 +12,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="icon" type="image/png" href="/icon.png">
-    <meta property="og:image" content="/icon.png">
+    <link rel="icon" type="image/png" href="icon.png">
+    <meta property="og:image" content="icon.png">
 </head>
 <body>
     <header class="header">


### PR DESCRIPTION
## Summary
- load favicon correctly by using a relative `icon.png` path in HTML and JS templates

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b9d247174483259a30ff3f07a905f3