### PR TITLE
Add Jtech Forums signup navigation button

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 * Rewrite **tutorial** to be larger, clearer, and more “for dummies” friendly
 * Update overall **color scheme** → switch from purple to blue
 * Display **install counts per filter** directly on each MDM card
-* Add a **Sign Up** button to encourage joining JTech Forums
 
 ### Run
 `npm install`

--- a/console.html
+++ b/console.html
@@ -23,6 +23,7 @@
                 <a class="nav-btn" href="/">MDM Installer</a>
                 <button class="nav-btn" id="tutorialBtn">Tutorial</button>
                 <button class="nav-btn" id="aboutBtn">About</button>
+                <a class="nav-btn" id="forumsBtn" href="https://forums.jtechforums.org/signup" target="_blank" rel="noopener noreferrer">Jtech Forums</a>
                 <a class="nav-btn" id="contactBtn" href="https://jtechforums.org/contact-us" target="_blank" rel="noopener noreferrer">Contact Us</a>
             </nav>
         </div>

--- a/js/page.js
+++ b/js/page.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 <nav class="nav">
                     <button class="nav-btn" id="tutorialBtn">Tutorial</button>
                     <button class="nav-btn" id="aboutBtn">About</button>
+                    <a class="nav-btn" id="forumsBtn" href="https://forums.jtechforums.org/signup" target="_blank" rel="noopener noreferrer">Jtech Forums</a>
                     <a class="nav-btn" id="contactBtn" href="https://jtechforums.org/contact-us" target="_blank" rel="noopener noreferrer">Contact Us</a>
                 </nav>
             </div>

--- a/template.html
+++ b/template.html
@@ -25,6 +25,7 @@
             <nav class="nav">
                 <button class="nav-btn" id="tutorialBtn">Tutorial</button>
                 <button class="nav-btn" id="aboutBtn">About</button>
+                <a class="nav-btn" id="forumsBtn" href="https://forums.jtechforums.org/signup" target="_blank" rel="noopener noreferrer">Jtech Forums</a>
                 <a class="nav-btn" id="contactBtn" href="https://jtechforums.org/contact-us" target="_blank" rel="noopener noreferrer">Contact Us</a>
             </nav>
         </div>


### PR DESCRIPTION
## Summary
- Add "Jtech Forums" nav button linking to forums sign-up page across templates and console views
- Remove completed JTech Forums sign-up TODO from README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9d2cfe004832594087b68eee8e127