### PR TITLE
Fix mobile warning scaling for small screens

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -779,6 +779,12 @@ body {
     padding: 0;
     align-items: stretch;
     z-index: 1100;
+    right: auto;
+    bottom: auto;
+    width: calc(100% * var(--page-scale));
+    height: calc(100% * var(--page-scale));
+    transform: scale(calc(1 / var(--page-scale)));
+    transform-origin: top left;
 }
 
 #mobileWarningModal .modal-content {


### PR DESCRIPTION
## Summary
- Prevent mobile warning modal from scaling down with the rest of the page
- Ensure warning overlay covers the full viewport on small screens

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9dac83384832592ce4872a0abfa51