### PR TITLE
Ensure logo is copied to build output

### DIFF
--- a/build.js
+++ b/build.js
@@ -27,6 +27,7 @@ const items = [
   { src: 'template.html', dest: 'index.html' },
   { src: 'console.html', dest: 'console.html' },
   { src: 'privacy.txt', dest: 'privacy.txt' },
+  { src: 'logo2.png', dest: 'logo2.png' },
   { src: 'css', dest: 'css' },
   { src: 'js', dest: 'js' },
   { src: 'apk', dest: 'apk' },


### PR DESCRIPTION
## Summary
- copy `logo2.png` into the `docs` folder during build so the top-right logo loads when deployed

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9e9019a908325bd29309b668fb68e