### PR TITLE
fix pages workflow to deploy docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,40 +47,26 @@ jobs:
 
       - name: Build site
         run: npm run build
-
-      # Detect common static output directories
-      - name: Detect output directory
-        id: detect
-        run: |
-          for d in dist build out .next/out .output/public public docs; do
-            if [ -d "$d" ]; then
-              echo "dir=$d" >> $GITHUB_OUTPUT
-              echo "Detected output dir: $d"
-              exit 0
-            fi
-          done
-          echo "ERROR: Could not find a build output directory (looked for dist, build, out, .next/out, .output/public, public, docs)."
-          exit 1
-
+      
       - name: List files (debug)
-        run: ls -la "${{ steps.detect.outputs.dir }}"
+        run: ls -la docs
 
       - name: "Preflight: ensure index.html exists"
         run: |
-          if [ ! -f "${{ steps.detect.outputs.dir }}/index.html" ]; then
-            echo "ERROR: No index.html found in ${{ steps.detect.outputs.dir }}."
+          if [ ! -f "docs/index.html" ]; then
+            echo "ERROR: No index.html found in docs."
             echo "If you're using Next.js, make sure you ran 'next export' (not just next build)."
             exit 1
           fi
 
       # Write the CNAME so GitHub binds your custom domain
       - name: Add CNAME
-        run: echo "installer.jtechforums.org" > "${{ steps.detect.outputs.dir }}/CNAME"
+        run: echo "installer.jtechforums.org" > docs/CNAME
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: ${{ steps.detect.outputs.dir }}
+          path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/build.js
+++ b/build.js
@@ -9,6 +9,7 @@ function copyRecursive(src, dest) {
   if (stat.isDirectory()) {
     fs.mkdirSync(dest, { recursive: true });
     for (const entry of fs.readdirSync(src)) {
+      if (entry === 'url.txt') continue; // skip helper metadata files
       copyRecursive(path.join(src, entry), path.join(dest, entry));
     }
   } else {
@@ -71,7 +72,12 @@ function generateApkMetadata() {
         }
       }
 
-      const apkUrl = `https://pub-587c8a0ce03148689a821b1655d304f5.r2.dev/${dir.name}.apk`;
+      // Allow per-app override of APK URL via optional url.txt
+      let apkUrl = `https://pub-587c8a0ce03148689a821b1655d304f5.r2.dev/${dir.name}.apk`;
+      const urlPath = path.join(dirPath, 'url.txt');
+      if (fs.existsSync(urlPath)) {
+        apkUrl = fs.readFileSync(urlPath, 'utf8').trim();
+      }
 
       return {
         name: dir.name,


### PR DESCRIPTION
## Summary
- simplify GitHub Pages workflow to deploy `docs` directly
- check for generated `index.html` in docs and write CNAME before uploading
- allow overriding APK download URLs via per-app `url.txt`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c0c404f0d883279663cb85fd4bc735